### PR TITLE
Adjust speed of pixel clock for uConsole display

### DIFF
--- a/rt-thread/bsp/allwinner/libraries/sunxi-hal/hal/source/disp2/soc/cwu50_config.c
+++ b/rt-thread/bsp/allwinner/libraries/sunxi-hal/hal/source/disp2/soc/cwu50_config.c
@@ -69,7 +69,7 @@ struct property_t g_lcd0_config_soc[] = {
     {
         .name = "lcd_dclk_freq",
         .type = PROPERTY_INTGER,
-        .v.value = 62,
+        .v.value = 67,
     },
     {
         .name = "lcd_pwm_used",


### PR DESCRIPTION
As per this thread: https://forum.clockworkpi.com/t/r-01-risc-v-baremetal-with-rt-thread-lcd-work-usb-in-progress/14683/9
Bumping up the pixel clock allows the screen to actually draw pixels, but it is still unclear if it affects LCD screen life.